### PR TITLE
Add core components and styling for 12-week planner

### DIFF
--- a/components/ActivityScreen.tsx
+++ b/components/ActivityScreen.tsx
@@ -1,0 +1,267 @@
+import React, { useMemo, useState } from 'react';
+import { CATEGORY_DETAILS } from '../constants';
+import { calculateGoalProgressForWeek, getWeekNumber } from '../utils';
+import { Activity, CategoryType, Goal, User } from '../types';
+import { CheckIcon, ChevronLeftIcon, PlusIcon, TrashIcon } from './Icons';
+
+interface ActivityScreenProps {
+  user: User;
+  categoryType: CategoryType;
+  goal: Goal;
+  onUpdateUser: (user: User) => void;
+  onBack: () => void;
+}
+
+export const ActivityScreen: React.FC<ActivityScreenProps> = ({
+  user,
+  categoryType,
+  goal,
+  onUpdateUser,
+  onBack,
+}) => {
+  const [activityName, setActivityName] = useState('');
+  const [error, setError] = useState('');
+
+  const category = user.categories[categoryType];
+  const syncedGoal = useMemo(() => category.goals.find((item) => item.id === goal.id) ?? goal, [category.goals, goal.id, goal]);
+  const currentWeek = getWeekNumber(user.startDate, user.totalWeeks);
+  const weeks = useMemo(() => Array.from({ length: user.totalWeeks }, (_, index) => index), [user.totalWeeks]);
+
+  if (!syncedGoal) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="max-w-md rounded-3xl border border-dashed border-slate-300 dark:border-slate-700 bg-white/60 dark:bg-slate-900/60 p-10 text-center">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Målet kunde inte hittas. Det kan ha raderats. Gå tillbaka och välj ett annat mål.
+          </p>
+          <button
+            onClick={onBack}
+            className="mt-6 inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-700"
+          >
+            <ChevronLeftIcon className="w-4 h-4" /> Tillbaka
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const handleAddActivity = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!activityName.trim()) {
+      setError('Namnge aktiviteten, t.ex. "Tre gympass".');
+      return;
+    }
+
+    const newActivity: Activity = {
+      id: Date.now().toString(),
+      name: activityName.trim(),
+      completed: Array.from({ length: user.totalWeeks }, () => false),
+    };
+
+    const updatedGoals = category.goals.map((goalItem) =>
+      goalItem.id === syncedGoal.id ? { ...goalItem, activities: [...goalItem.activities, newActivity] } : goalItem,
+    );
+
+    onUpdateUser({
+      ...user,
+      categories: {
+        ...user.categories,
+        [categoryType]: {
+          ...category,
+          goals: updatedGoals,
+        },
+      },
+    });
+
+    setActivityName('');
+    setError('');
+  };
+
+  const updateActivity = (activityId: string, updater: (activity: Activity) => Activity) => {
+    const updatedGoals = category.goals.map((goalItem) => {
+      if (goalItem.id !== syncedGoal.id) {
+        return goalItem;
+      }
+      return {
+        ...goalItem,
+        activities: goalItem.activities.map((activity) =>
+          activity.id === activityId ? updater(activity) : activity,
+        ),
+      };
+    });
+
+    onUpdateUser({
+      ...user,
+      categories: {
+        ...user.categories,
+        [categoryType]: {
+          ...category,
+          goals: updatedGoals,
+        },
+      },
+    });
+  };
+
+  const handleToggleWeek = (activityId: string, weekIndex: number) => {
+    updateActivity(activityId, (activity) => {
+      const completed = [...activity.completed];
+      if (completed.length <= weekIndex) {
+        const extension = Array.from({ length: weekIndex - completed.length + 1 }, () => false);
+        completed.push(...extension);
+      }
+      completed[weekIndex] = !completed[weekIndex];
+      return { ...activity, completed };
+    });
+  };
+
+  const handleDeleteActivity = (activityId: string) => {
+    if (!window.confirm('Vill du ta bort aktiviteten?')) {
+      return;
+    }
+
+    const updatedGoals = category.goals.map((goalItem) => {
+      if (goalItem.id !== syncedGoal.id) {
+        return goalItem;
+      }
+      return {
+        ...goalItem,
+        activities: goalItem.activities.filter((activity) => activity.id !== activityId),
+      };
+    });
+
+    onUpdateUser({
+      ...user,
+      categories: {
+        ...user.categories,
+        [categoryType]: {
+          ...category,
+          goals: updatedGoals,
+        },
+      },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-100 via-slate-200 to-slate-300 dark:from-slate-950 dark:via-slate-900 dark:to-slate-800">
+      <div className="mx-auto max-w-5xl px-4 py-10 space-y-8">
+        <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onBack}
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-300/70 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/80 dark:hover:bg-slate-800/60"
+            >
+              <ChevronLeftIcon className="w-4 h-4" /> Tillbaka
+            </button>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">{CATEGORY_DETAILS[categoryType].name}</p>
+              <h1 className="text-3xl font-bold text-slate-900 dark:text-white">{syncedGoal.name}</h1>
+              <p className="text-xs text-slate-500">{syncedGoal.activities.length} aktiviteter · Vecka {currentWeek + 1}</p>
+            </div>
+          </div>
+          <div className="text-sm text-slate-500">
+            <p>{user.totalWeeks} veckor totalt</p>
+          </div>
+        </header>
+
+        <form onSubmit={handleAddActivity} className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6 space-y-4">
+          <div>
+            <label htmlFor="activity-name" className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-2">
+              Lägg till en aktivitet
+            </label>
+            <input
+              id="activity-name"
+              type="text"
+              value={activityName}
+              onChange={(event) => setActivityName(event.target.value)}
+              placeholder="Ex. Ring pappa på torsdag"
+              className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900 px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p className="mt-1 text-xs text-slate-500">Aktiviteter är konkreta handlingar du ska genomföra varje vecka.</p>
+          </div>
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <button
+            type="submit"
+            className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            <PlusIcon className="w-5 h-5" /> Lägg till aktivitet
+          </button>
+        </form>
+
+        <section className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6 overflow-x-auto">
+          {syncedGoal.activities.length === 0 ? (
+            <div className="py-10 text-center text-sm text-slate-600 dark:text-slate-300">
+              Du har inga aktiviteter ännu. Lägg till en ovan för att börja spåra.
+            </div>
+          ) : (
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-slate-500">
+                  <th className="px-3 py-2">Aktivitet</th>
+                  {weeks.map((week) => (
+                    <th key={week} className={`px-3 py-2 text-center ${week === currentWeek ? 'text-blue-600' : ''}`}>
+                      Vecka {week + 1}
+                    </th>
+                  ))}
+                  <th className="px-3 py-2 text-center">Ta bort</th>
+                </tr>
+              </thead>
+              <tbody>
+                {syncedGoal.activities.map((activity) => (
+                  <tr key={activity.id} className="border-t border-slate-200/70 dark:border-slate-800/70">
+                    <td className="px-3 py-3 font-medium text-slate-800 dark:text-slate-100">{activity.name}</td>
+                    {weeks.map((week) => (
+                      <td key={week} className="px-3 py-2 text-center">
+                        <button
+                          type="button"
+                          onClick={() => handleToggleWeek(activity.id, week)}
+                          className={`mx-auto flex h-8 w-8 items-center justify-center rounded-full border transition ${
+                            activity.completed[week]
+                              ? 'border-emerald-400 bg-emerald-100 text-emerald-700 dark:border-emerald-500/60 dark:bg-emerald-500/10 dark:text-emerald-200'
+                              : 'border-slate-300 dark:border-slate-700 text-slate-400 hover:border-blue-400 hover:text-blue-500'
+                          } ${week === currentWeek ? 'ring-2 ring-blue-200 dark:ring-blue-500/40' : ''}`}
+                        >
+                          {activity.completed[week] ? <CheckIcon className="w-4 h-4" /> : week + 1}
+                        </button>
+                      </td>
+                    ))}
+                    <td className="px-3 py-2 text-center">
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteActivity(activity.id)}
+                        className="inline-flex items-center justify-center rounded-lg border border-slate-300/60 dark:border-slate-700 px-3 py-1 text-xs text-slate-500 hover:bg-slate-100/80 dark:hover:bg-slate-800/60"
+                      >
+                        <TrashIcon className="w-4 h-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        <section className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Veckoresultat</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 md:grid-cols-3">
+            {weeks.map((week) => {
+              const progress = calculateGoalProgressForWeek(syncedGoal, week);
+              return (
+                <div
+                  key={week}
+                  className={`rounded-2xl border px-4 py-4 text-sm transition ${
+                    week === currentWeek
+                      ? 'border-blue-300/70 bg-blue-50/70 text-blue-700 dark:border-blue-600/60 dark:bg-blue-600/10 dark:text-blue-100'
+                      : 'border-slate-200 dark:border-slate-700 bg-white/60 dark:bg-slate-900/50 text-slate-600 dark:text-slate-300'
+                  }`}
+                >
+                  <p className="font-semibold">Vecka {week + 1}</p>
+                  <p className="text-xs opacity-80">{progress === null ? 'Ingen data' : `${progress}% klart`}</p>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,0 +1,236 @@
+import React, { useEffect, useMemo } from 'react';
+import { Achievement } from '../achievements';
+import { CATEGORY_DETAILS } from '../constants';
+import { motivationalQuotes } from '../quotes';
+import { ActivityInfo, calculateOverallWeeklyProgress, calculateWeeklyProgress, getIncompleteActivitiesForWeek, getWeekNumber } from '../utils';
+import { CategoryType, User } from '../types';
+import { ACHIEVEMENT_DETAILS } from '../achievements';
+import {
+  CalendarIcon,
+  ClipboardIcon,
+  LogoutIcon,
+  PlusIcon,
+  TargetIcon,
+  TrophyIcon,
+  CheckIcon,
+} from './Icons';
+
+interface DashboardProps {
+  user: User;
+  onSelectCategory: (category: CategoryType) => void;
+  onSelectActivity: (category: CategoryType, goalId: string) => void;
+  onLogout: () => void;
+  onGoToReview: () => void;
+  newlyUnlocked: Achievement[];
+  onClearNewlyUnlocked: () => void;
+}
+
+const getQuoteForWeek = (week: number) => motivationalQuotes[week % motivationalQuotes.length];
+
+export const Dashboard: React.FC<DashboardProps> = ({
+  user,
+  onSelectCategory,
+  onSelectActivity,
+  onLogout,
+  onGoToReview,
+  newlyUnlocked,
+  onClearNewlyUnlocked,
+}) => {
+  const currentWeek = getWeekNumber(user.startDate, user.totalWeeks);
+  const overallProgress = calculateOverallWeeklyProgress(user, currentWeek);
+
+  const incompleteActivities = useMemo(() => {
+    if (overallProgress === null) {
+      return [] as ActivityInfo[];
+    }
+    return getIncompleteActivitiesForWeek(user, currentWeek);
+  }, [user, currentWeek, overallProgress]);
+
+  const unlockedAchievements = useMemo(
+    () => user.achievements.map((id) => ACHIEVEMENT_DETAILS[id]).filter(Boolean),
+    [user.achievements],
+  );
+
+  useEffect(() => {
+    if (newlyUnlocked.length === 0) {
+      return;
+    }
+    const timeout = window.setTimeout(() => onClearNewlyUnlocked(), 5000);
+    return () => window.clearTimeout(timeout);
+  }, [newlyUnlocked, onClearNewlyUnlocked]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-100 via-slate-200 to-slate-300 dark:from-slate-950 dark:via-slate-900 dark:to-slate-800">
+      <div className="mx-auto max-w-6xl px-4 py-10 space-y-10">
+        <header className="flex flex-col gap-4 rounded-3xl bg-white/80 dark:bg-slate-950/70 backdrop-blur border border-white/40 dark:border-slate-800 p-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-wide text-slate-500">Välkommen tillbaka</p>
+            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">{user.name}</h1>
+            <p className="text-sm text-slate-500 mt-1 flex items-center gap-2">
+              <CalendarIcon className="w-4 h-4" /> Vecka {currentWeek + 1} av {user.totalWeeks}
+            </p>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-3">
+            <button
+              onClick={onGoToReview}
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              <ClipboardIcon className="w-5 h-5" /> Veckoöversyn
+            </button>
+            <button
+              onClick={onLogout}
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-300/60 dark:border-slate-700 px-5 py-3 text-sm font-semibold text-slate-700 dark:text-slate-200 hover:bg-slate-100/80 dark:hover:bg-slate-800/60 focus:outline-none focus:ring-2 focus:ring-slate-400"
+            >
+              <LogoutIcon className="w-5 h-5" /> Logga ut
+            </button>
+          </div>
+        </header>
+
+        {newlyUnlocked.length > 0 && (
+          <div className="animate-fadeIn rounded-3xl border border-amber-200 bg-amber-50/90 dark:border-amber-500/60 dark:bg-amber-500/10 p-6 text-amber-800 dark:text-amber-200 shadow">
+            <div className="flex items-center gap-3 mb-3">
+              <TrophyIcon className="w-7 h-7" />
+              <div>
+                <h2 className="text-lg font-semibold">Nya utmärkelser låsta!</h2>
+                <p className="text-sm text-amber-700/80 dark:text-amber-200/80">
+                  Fira dina framsteg – fortsätt i samma takt.
+                </p>
+              </div>
+            </div>
+            <ul className="flex flex-wrap gap-3">
+              {newlyUnlocked.map((achievement) => (
+                <li key={achievement.id} className="flex items-center gap-2 rounded-2xl bg-white/70 dark:bg-slate-900/60 px-4 py-2 text-sm">
+                  <achievement.icon className="w-5 h-5" />
+                  <div>
+                    <p className="font-semibold">{achievement.name}</p>
+                    <p className="text-xs text-amber-600 dark:text-amber-200/80">{achievement.description}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <section className="grid gap-6 md:grid-cols-[2fr_1fr]">
+          <div className="space-y-6">
+            <div className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm text-slate-500">Totalt veckoupplägg</p>
+                  <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+                    {overallProgress === null ? 'Inga aktiviteter än' : `${overallProgress}% avklarat denna vecka`}
+                  </h2>
+                </div>
+                <div className="text-right text-sm text-slate-500">
+                  <p>Startade {new Date(user.startDate).toLocaleDateString()}</p>
+                  <p className="italic">“{getQuoteForWeek(currentWeek)}”</p>
+                </div>
+              </div>
+              <div className="mt-4 h-3 rounded-full bg-slate-200/60 dark:bg-slate-800/80 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-blue-500 transition-all"
+                  style={{ width: `${overallProgress ?? 0}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {(Object.keys(user.categories) as CategoryType[]).map((category) => {
+                const details = CATEGORY_DETAILS[category];
+                const progress = calculateWeeklyProgress(user, category, currentWeek);
+                const goalsCount = user.categories[category].goals.length;
+                return (
+                  <button
+                    key={category}
+                    onClick={() => onSelectCategory(category)}
+                    className={`group relative overflow-hidden rounded-3xl border px-5 py-6 text-left shadow-sm transition ${details.color} ${details.darkColor} ${details.borderColor} ${details.darkBorderColor} hover:shadow-lg ${details.hoverColor} ${details.darkHoverColor}`}
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className={`text-xs uppercase tracking-wide ${details.textColor} ${details.darkTextColor}`}>
+                          {details.name}
+                        </p>
+                        <p className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">{progress ?? 0}%</p>
+                        <p className="text-xs text-slate-600 dark:text-slate-300 mt-1">
+                          {goalsCount} mål
+                        </p>
+                      </div>
+                      <div className="rounded-full bg-white/70 dark:bg-slate-900/70 p-3 shadow-inner">
+                        <details.icon className={`w-6 h-6 ${details.textColor} ${details.darkTextColor}`} />
+                      </div>
+                    </div>
+                    <div className="mt-4 h-2 rounded-full bg-white/40 dark:bg-slate-900/50 overflow-hidden">
+                      <div
+                        className={`h-full ${details.progressBg} ${details.darkProgressBg}`}
+                        style={{ width: `${progress ?? 0}%` }}
+                      />
+                    </div>
+                    <div className="mt-4 flex items-center justify-between text-xs text-slate-600 dark:text-slate-300">
+                      <span className="inline-flex items-center gap-1">
+                        <TargetIcon className="w-4 h-4" /> Se mål
+                      </span>
+                      <span className="opacity-0 transition group-hover:opacity-100 flex items-center gap-1">
+                        <PlusIcon className="w-4 h-4" /> Lägg till mål
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <aside className="space-y-6">
+            <div className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Veckans fokus</h3>
+              {incompleteActivities.length === 0 ? (
+                <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+                  Alla aktiviteter är avklarade för denna vecka. Grymt jobbat!
+                </p>
+              ) : (
+                <ul className="mt-4 space-y-3">
+                  {incompleteActivities.slice(0, 6).map(({ activity, goalName, goalId, categoryType }) => (
+                    <li key={activity.id} className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900/60 px-4 py-3 text-sm">
+                      <p className="font-semibold text-slate-800 dark:text-slate-100">{activity.name}</p>
+                      <p className="text-xs text-slate-500">{goalName}</p>
+                      <button
+                        onClick={() => onSelectActivity(categoryType, goalId)}
+                        className="mt-2 inline-flex items-center gap-1 rounded-lg bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-600 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-300"
+                      >
+                        <CheckIcon className="w-4 h-4" /> Markera klar
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-4">Utmärkelser</h3>
+              <ul className="space-y-3">
+                {Object.values(ACHIEVEMENT_DETAILS).map((achievement) => {
+                  const unlocked = unlockedAchievements.some((item) => item.id === achievement.id);
+                  return (
+                    <li
+                      key={achievement.id}
+                      className={`flex items-center gap-3 rounded-2xl border px-4 py-3 text-sm transition ${
+                        unlocked
+                          ? 'border-emerald-300/70 bg-emerald-50/70 text-emerald-700 dark:border-emerald-600/50 dark:bg-emerald-600/10 dark:text-emerald-200'
+                          : 'border-slate-200 dark:border-slate-700 bg-white/60 dark:bg-slate-900/50 text-slate-500'
+                      }`}
+                    >
+                      <achievement.icon className="w-5 h-5" />
+                      <div>
+                        <p className="font-semibold">{achievement.name}</p>
+                        <p className="text-xs opacity-80">{achievement.description}</p>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </aside>
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/components/GoalScreen.tsx
+++ b/components/GoalScreen.tsx
@@ -1,0 +1,185 @@
+import React, { useMemo, useState } from 'react';
+import { CATEGORY_DETAILS } from '../constants';
+import { calculateGoalProgressForWeek, getWeekNumber } from '../utils';
+import { CategoryType, Goal, User } from '../types';
+import { ChevronLeftIcon, PlusIcon, TrashIcon } from './Icons';
+
+interface GoalScreenProps {
+  user: User;
+  categoryType: CategoryType;
+  onUpdateUser: (user: User) => void;
+  onSelectGoal: (goal: Goal) => void;
+  onBack: () => void;
+}
+
+export const GoalScreen: React.FC<GoalScreenProps> = ({
+  user,
+  categoryType,
+  onUpdateUser,
+  onSelectGoal,
+  onBack,
+}) => {
+  const [goalName, setGoalName] = useState('');
+  const [error, setError] = useState('');
+
+  const categoryDetails = CATEGORY_DETAILS[categoryType];
+  const goals = user.categories[categoryType].goals;
+  const currentWeek = getWeekNumber(user.startDate, user.totalWeeks);
+
+  const sortedGoals = useMemo(() => {
+    return [...goals].sort((a, b) => a.name.localeCompare(b.name, 'sv'));
+  }, [goals]);
+
+  const handleAddGoal = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!goalName.trim()) {
+      setError('Sätt ett tydligt namn på målet.');
+      return;
+    }
+
+    const newGoal: Goal = {
+      id: Date.now().toString(),
+      name: goalName.trim(),
+      activities: [],
+    };
+
+    const updatedUser: User = {
+      ...user,
+      categories: {
+        ...user.categories,
+        [categoryType]: {
+          ...user.categories[categoryType],
+          goals: [...goals, newGoal],
+        },
+      },
+    };
+
+    onUpdateUser(updatedUser);
+    setGoalName('');
+    setError('');
+  };
+
+  const handleDeleteGoal = (goalId: string) => {
+    if (!window.confirm('Är du säker på att du vill radera målet och dess aktiviteter?')) {
+      return;
+    }
+
+    const updatedGoals = goals.filter((goal) => goal.id !== goalId);
+    const updatedUser: User = {
+      ...user,
+      categories: {
+        ...user.categories,
+        [categoryType]: {
+          ...user.categories[categoryType],
+          goals: updatedGoals,
+        },
+      },
+    };
+
+    onUpdateUser(updatedUser);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-100 via-slate-200 to-slate-300 dark:from-slate-950 dark:via-slate-900 dark:to-slate-800">
+      <div className="mx-auto max-w-4xl px-4 py-10 space-y-8">
+        <header className="flex items-center gap-4">
+          <button
+            onClick={onBack}
+            className="inline-flex items-center gap-2 rounded-xl border border-slate-300/70 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/80 dark:hover:bg-slate-800/60"
+          >
+            <ChevronLeftIcon className="w-4 h-4" /> Tillbaka
+          </button>
+          <div>
+            <p className={`text-xs uppercase tracking-wide ${categoryDetails.textColor} ${categoryDetails.darkTextColor}`}>
+              {categoryDetails.name}
+            </p>
+            <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Mål</h1>
+          </div>
+        </header>
+
+        <form onSubmit={handleAddGoal} className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6 space-y-4">
+          <div>
+            <label htmlFor="goal-name" className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-2">
+              Skapa ett nytt mål
+            </label>
+            <input
+              id="goal-name"
+              type="text"
+              value={goalName}
+              onChange={(event) => setGoalName(event.target.value)}
+              placeholder="Ex. Ha familjemiddag varje söndag"
+              className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900 px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <p className="mt-1 text-xs text-slate-500">Var konkret och mätbar.</p>
+          </div>
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
+          <button
+            type="submit"
+            className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            <PlusIcon className="w-5 h-5" /> Lägg till mål
+          </button>
+        </form>
+
+        <section className="space-y-4">
+          {sortedGoals.length === 0 ? (
+            <div className="rounded-3xl border border-dashed border-slate-300 dark:border-slate-700 bg-white/40 dark:bg-slate-950/40 p-10 text-center">
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                Du har inga mål ännu. Skapa ditt första för att börja planera dina aktiviteter.
+              </p>
+            </div>
+          ) : (
+            sortedGoals.map((goal) => {
+              const weeklyProgress = calculateGoalProgressForWeek(goal, currentWeek);
+              return (
+                <article
+                  key={goal.id}
+                  className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6 flex flex-col gap-4"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{goal.name}</h2>
+                      <p className="text-xs text-slate-500">{goal.activities.length} aktiviteter kopplade</p>
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => onSelectGoal(goal)}
+                        className="rounded-xl bg-blue-600/90 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                      >
+                        Hantera aktiviteter
+                      </button>
+                      <button
+                        onClick={() => handleDeleteGoal(goal.id)}
+                        className="rounded-xl border border-slate-300/60 dark:border-slate-700 px-4 py-2 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-100/70 dark:hover:bg-slate-800/50"
+                        type="button"
+                        title="Radera mål"
+                      >
+                        <TrashIcon className="w-5 h-5" />
+                      </button>
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Veckans progression</p>
+                    <div className="mt-2 h-2 rounded-full bg-slate-200/70 dark:bg-slate-800/80 overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-blue-500"
+                        style={{ width: `${weeklyProgress ?? 0}%` }}
+                      />
+                    </div>
+                    <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                      {weeklyProgress === null
+                        ? 'Inga aktiviteter registrerade ännu.'
+                        : `${weeklyProgress}% av veckans aktiviteter klara.`}
+                    </p>
+                  </div>
+                </article>
+              );
+            })
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,0 +1,275 @@
+import React from 'react';
+
+type IconProps = {
+  className?: string;
+};
+
+const withBaseClass = (className?: string) => `w-6 h-6 ${className ?? ''}`.trim();
+
+export const FamilyIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="7" cy="7" r="3" />
+    <circle cx="17" cy="7" r="3" />
+    <path d="M2 21v-1a5 5 0 0 1 5-5h2a5 5 0 0 1 5 5v1" />
+    <path d="M15 21v-2a4 4 0 0 1 4-4h1a2 2 0 0 1 2 2v4" />
+  </svg>
+);
+
+export const HealthIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 21s-6-4.35-9-8.25C-0.5 8.5 1 4 4.5 3.5c2.25-.32 3.79 1.43 4.5 2.74.71-1.31 2.25-3.06 4.5-2.74C18 4 19.5 8.5 15 12.75 12 16.65 12 21 12 21Z" />
+  </svg>
+);
+
+export const CareerIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 7h18v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Z" />
+    <path d="M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <path d="M3 11h18" />
+  </svg>
+);
+
+export const DevelopmentIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M4 19.5V5a1 1 0 0 1 1-1h9l6 6v9.5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1Z" />
+    <path d="m14 4 6 6" />
+    <path d="M9 13h6" />
+    <path d="M9 17h4" />
+  </svg>
+);
+
+export const TrophyIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M8 21h8" />
+    <path d="M12 17v4" />
+    <path d="M8 4h8v5a4 4 0 0 1-4 4 4 4 0 0 1-4-4V4Z" />
+    <path d="M4 6h2v2a4 4 0 0 1-4-4V4h4" />
+    <path d="M20 6h-2v2a4 4 0 0 0 4-4V4h-4" />
+  </svg>
+);
+
+export const StarIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 3 9.09 8.26 3 9.27l4.5 4.38L6.18 21 12 17.77 17.82 21l-1.32-7.35L21 9.27l-6.09-.99L12 3Z" />
+  </svg>
+);
+
+export const StreakIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8Z" />
+  </svg>
+);
+
+export const GoalIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="9" />
+    <circle cx="12" cy="12" r="5" />
+    <path d="M12 7v5l3 2" />
+  </svg>
+);
+
+export const ReviewIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M4 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H8l-4 5V5Z" />
+    <path d="M8 9h8" />
+    <path d="M8 13h4" />
+  </svg>
+);
+
+export const LogoutIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <path d="M16 17 21 12 16 7" />
+    <path d="M21 12H9" />
+  </svg>
+);
+
+export const PlusIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 5v14" />
+    <path d="M5 12h14" />
+  </svg>
+);
+
+export const ChevronLeftIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m15 18-6-6 6-6" />
+  </svg>
+);
+
+export const CheckIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m5 13 4 4L19 7" />
+  </svg>
+);
+
+export const TrashIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 6h18" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <path d="M19 6v13a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+  </svg>
+);
+
+export const CalendarIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M8 2v4" />
+    <path d="M16 2v4" />
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <path d="M3 10h18" />
+  </svg>
+);
+
+export const TargetIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="9" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const ClipboardIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    className={withBaseClass(className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M16 4h1a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1" />
+    <rect x="9" y="2" width="6" height="4" rx="1" />
+    <path d="M9 12h6" />
+    <path d="M9 16h4" />
+  </svg>
+);

--- a/components/UserLoginScreen.tsx
+++ b/components/UserLoginScreen.tsx
@@ -1,0 +1,173 @@
+import React, { useMemo, useState } from 'react';
+import { User } from '../types';
+import { motivationalQuotes } from '../quotes';
+import { CalendarIcon, PlusIcon, TrashIcon } from './Icons';
+
+interface UserLoginScreenProps {
+  users: User[];
+  onAddUser: (name: string, startDate: Date, totalWeeks: number) => void;
+  onSelectUser: (user: User) => void;
+  onDeleteUser: (userId: string) => void;
+}
+
+export const UserLoginScreen: React.FC<UserLoginScreenProps> = ({
+  users,
+  onAddUser,
+  onSelectUser,
+  onDeleteUser,
+}) => {
+  const [name, setName] = useState('');
+  const [startDate, setStartDate] = useState(() => new Date().toISOString().split('T')[0]);
+  const [totalWeeks, setTotalWeeks] = useState(12);
+  const [error, setError] = useState('');
+
+  const inspirationalQuote = useMemo(() => {
+    return motivationalQuotes[Math.floor(Math.random() * motivationalQuotes.length)];
+  }, []);
+
+  const resetForm = () => {
+    setName('');
+    setStartDate(new Date().toISOString().split('T')[0]);
+    setTotalWeeks(12);
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!name.trim()) {
+      setError('Ange ett namn för att skapa en plan.');
+      return;
+    }
+
+    if (!startDate) {
+      setError('Välj ett startdatum.');
+      return;
+    }
+
+    if (!Number.isFinite(totalWeeks) || totalWeeks < 4 || totalWeeks > 52) {
+      setError('Antalet veckor bör vara mellan 4 och 52.');
+      return;
+    }
+
+    onAddUser(name.trim(), new Date(startDate), totalWeeks);
+    setError('');
+    resetForm();
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-100 via-slate-200 to-slate-300 dark:from-slate-950 dark:via-slate-900 dark:to-slate-800 flex items-center justify-center px-4 py-10">
+      <div className="w-full max-w-5xl grid gap-8 lg:grid-cols-[1.3fr_1fr]">
+        <div className="bg-white/80 dark:bg-slate-950/70 backdrop-blur rounded-3xl shadow-xl border border-white/40 dark:border-slate-800 p-10">
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">12+M</h1>
+          <p className="text-lg text-slate-600 dark:text-slate-300 mb-8">
+            Bygg en 12-veckorsplan, håll koll på dina aktiviteter och följ upp varje vecka.
+          </p>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-2" htmlFor="name">
+                Ditt namn
+              </label>
+              <input
+                id="name"
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Ex. Alex"
+                className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900 px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              <div>
+                <label className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-2" htmlFor="start-date">
+                  Startdatum
+                </label>
+                <div className="relative">
+                  <CalendarIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+                  <input
+                    id="start-date"
+                    type="date"
+                    value={startDate}
+                    onChange={(event) => setStartDate(event.target.value)}
+                    className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900 pl-10 pr-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-2" htmlFor="total-weeks">
+                  Antal veckor
+                </label>
+                <input
+                  id="total-weeks"
+                  type="number"
+                  min={4}
+                  max={52}
+                  value={totalWeeks}
+                  onChange={(event) => setTotalWeeks(Number(event.target.value))}
+                  className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900 px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <p className="mt-1 text-xs text-slate-500">Standard är 12 veckor, men du kan justera efter din plan.</p>
+              </div>
+            </div>
+
+            {error && <p className="text-sm text-red-500">{error}</p>}
+
+            <button
+              type="submit"
+              className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-3 font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              <PlusIcon className="w-5 h-5" />
+              Skapa plan
+            </button>
+          </form>
+        </div>
+
+        <div className="space-y-6">
+          <div className="h-full bg-white/80 dark:bg-slate-950/70 backdrop-blur rounded-3xl shadow-xl border border-white/40 dark:border-slate-800 p-8">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-white mb-4">Välj tidigare plan</h2>
+            {users.length === 0 ? (
+              <p className="text-sm text-slate-500">
+                När du skapar en plan visas den här. Du kan skapa flera och växla mellan dem.
+              </p>
+            ) : (
+              <ul className="space-y-4">
+                {users.map((user) => (
+                  <li key={user.id} className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900 px-4 py-3">
+                    <div>
+                      <p className="font-semibold text-slate-800 dark:text-slate-100">{user.name}</p>
+                      <p className="text-xs text-slate-500">
+                        Start: {new Date(user.startDate).toLocaleDateString()} · {user.totalWeeks} veckor
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => onSelectUser(user)}
+                        className="rounded-lg bg-blue-50 px-3 py-2 text-sm font-semibold text-blue-600 hover:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                      >
+                        Öppna
+                      </button>
+                      <button
+                        onClick={() => onDeleteUser(user.id)}
+                        className="rounded-lg p-2 text-slate-400 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-400"
+                        title="Radera användare"
+                        type="button"
+                      >
+                        <TrashIcon className="w-5 h-5" />
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="bg-white/70 dark:bg-slate-950/60 backdrop-blur rounded-3xl shadow border border-white/30 dark:border-slate-800 p-6">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Dagens inspiration</h2>
+            <p className="mt-3 text-base text-slate-700 dark:text-slate-200 leading-relaxed">“{inspirationalQuote}”</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/WeeklyReviewScreen.tsx
+++ b/components/WeeklyReviewScreen.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { CATEGORY_DETAILS } from '../constants';
+import { calculateOverallWeeklyProgress, calculateWeeklyProgress, getIncompleteActivitiesForWeek, getWeekNumber } from '../utils';
+import { CategoryType, User } from '../types';
+import { CheckIcon, ChevronLeftIcon, ClipboardIcon } from './Icons';
+
+interface WeeklyReviewScreenProps {
+  user: User;
+  onUpdateUser: (user: User) => void;
+  onBack: () => void;
+}
+
+export const WeeklyReviewScreen: React.FC<WeeklyReviewScreenProps> = ({ user, onUpdateUser, onBack }) => {
+  const currentWeek = getWeekNumber(user.startDate, user.totalWeeks);
+  const [selectedWeek, setSelectedWeek] = useState(() => currentWeek);
+  const [wentWell, setWentWell] = useState('');
+  const [couldBeImproved, setCouldBeImproved] = useState('');
+  const [statusMessage, setStatusMessage] = useState('');
+
+  const overallProgress = calculateOverallWeeklyProgress(user, selectedWeek);
+  const incompleteActivities = useMemo(
+    () => getIncompleteActivitiesForWeek(user, selectedWeek),
+    [user, selectedWeek],
+  );
+
+  useEffect(() => {
+    const existingReview = user.weeklyReviews.find((review) => review.weekNumber === selectedWeek);
+    setWentWell(existingReview?.wentWell ?? '');
+    setCouldBeImproved(existingReview?.couldBeImproved ?? '');
+  }, [selectedWeek, user.weeklyReviews]);
+
+  const handleSave = (event: React.FormEvent) => {
+    event.preventDefault();
+    const trimmedWentWell = wentWell.trim();
+    const trimmedCouldBeImproved = couldBeImproved.trim();
+
+    const filteredReviews = user.weeklyReviews.filter((review) => review.weekNumber !== selectedWeek);
+    const updatedReviews = [
+      ...filteredReviews,
+      {
+        weekNumber: selectedWeek,
+        wentWell: trimmedWentWell,
+        couldBeImproved: trimmedCouldBeImproved,
+      },
+    ];
+
+    onUpdateUser({
+      ...user,
+      weeklyReviews: updatedReviews,
+    });
+
+    setStatusMessage('Veckoöversyn sparad!');
+    setTimeout(() => setStatusMessage(''), 3000);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-100 via-slate-200 to-slate-300 dark:from-slate-950 dark:via-slate-900 dark:to-slate-800">
+      <div className="mx-auto max-w-5xl px-4 py-10 space-y-8">
+        <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onBack}
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-300/70 dark:border-slate-700 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/80 dark:hover:bg-slate-800/60"
+            >
+              <ChevronLeftIcon className="w-4 h-4" /> Tillbaka
+            </button>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Veckoöversyn</p>
+              <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Reflektera och planera</h1>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-blue-200/60 dark:border-blue-700/60 bg-blue-50/70 dark:bg-blue-500/10 px-4 py-3 text-sm text-blue-700 dark:text-blue-200 flex items-center gap-2">
+            <ClipboardIcon className="w-5 h-5" /> Vecka {selectedWeek + 1} av {user.totalWeeks}
+          </div>
+        </header>
+
+        <div className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6">
+          <label htmlFor="week" className="block text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Välj vecka att reflektera över
+          </label>
+          <select
+            id="week"
+            value={selectedWeek}
+            onChange={(event) => setSelectedWeek(Number(event.target.value))}
+            className="mt-2 w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900 px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {Array.from({ length: user.totalWeeks }, (_, index) => (
+              <option key={index} value={index}>
+                Vecka {index + 1}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <section className="grid gap-6 md:grid-cols-[1.5fr_1fr]">
+          <form onSubmit={handleSave} className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6 space-y-5">
+            <div>
+              <label htmlFor="went-well" className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-2">
+                Vad gick bra?
+              </label>
+              <textarea
+                id="went-well"
+                value={wentWell}
+                onChange={(event) => setWentWell(event.target.value)}
+                rows={5}
+                className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900 px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Fira dina segrar, stora som små."
+              />
+            </div>
+            <div>
+              <label htmlFor="could-be-improved" className="block text-sm font-medium text-slate-600 dark:text-slate-300 mb-2">
+                Vad kan förbättras?
+              </label>
+              <textarea
+                id="could-be-improved"
+                value={couldBeImproved}
+                onChange={(event) => setCouldBeImproved(event.target.value)}
+                rows={5}
+                className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900 px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Identifiera hinder och hur du tar dig förbi dem."
+              />
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <button
+                type="submit"
+                className="inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              >
+                <CheckIcon className="w-5 h-5" /> Spara reflektion
+              </button>
+              {statusMessage && <span className="text-sm text-emerald-600 dark:text-emerald-300">{statusMessage}</span>}
+            </div>
+          </form>
+
+          <aside className="space-y-6">
+            <div className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Veckans läge</h2>
+              <p className="mt-1 text-2xl font-semibold text-slate-900 dark:text-white">
+                {overallProgress === null ? 'Inga aktiviteter registrerade' : `${overallProgress}% avklarat`}
+              </p>
+              <div className="mt-3 h-2 rounded-full bg-slate-200/70 dark:bg-slate-800/80 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-blue-500"
+                  style={{ width: `${overallProgress ?? 0}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6 space-y-3">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Kategoriöversikt</h2>
+              {(Object.keys(user.categories) as CategoryType[]).map((category) => {
+                const details = CATEGORY_DETAILS[category];
+                const progress = calculateWeeklyProgress(user, category, selectedWeek);
+                return (
+                  <div key={category} className="flex items-center justify-between rounded-2xl border border-slate-200/70 dark:border-slate-700/70 bg-white/70 dark:bg-slate-900/50 px-4 py-3">
+                    <div className="flex items-center gap-3">
+                      <details.icon className={`w-5 h-5 ${details.textColor} ${details.darkTextColor}`} />
+                      <div>
+                        <p className="text-sm font-medium text-slate-700 dark:text-slate-200">{details.name}</p>
+                        <p className="text-xs text-slate-500">{progress === null ? 'Inga aktiviteter' : `${progress}%`}</p>
+                      </div>
+                    </div>
+                    <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{progress ?? 0}%</span>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="rounded-3xl border border-white/40 dark:border-slate-800 bg-white/80 dark:bg-slate-950/70 backdrop-blur p-6">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Ej klara aktiviteter</h2>
+              {incompleteActivities.length === 0 ? (
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Allt är avklarat för denna vecka.</p>
+              ) : (
+                <ul className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-200">
+                  {incompleteActivities.map(({ activity, goalName }) => (
+                    <li key={activity.id} className="rounded-xl border border-slate-200/70 dark:border-slate-700/70 bg-white/60 dark:bg-slate-900/50 px-3 py-2">
+                      <p className="font-semibold">{activity.name}</p>
+                      <p className="text-xs text-slate-500">{goalName}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </aside>
+        </section>
+      </div>
+    </div>
+  );
+};

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+
+function readValue<T>(key: string, initialValue: T): T {
+  if (typeof window === 'undefined') {
+    return initialValue;
+  }
+
+  try {
+    const item = window.localStorage.getItem(key);
+    return item ? (JSON.parse(item) as T) : initialValue;
+  } catch (error) {
+    console.warn(`useLocalStorage: Failed to read key "${key}"`, error);
+    return initialValue;
+  }
+}
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => readValue<T>(key, initialValue));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(key, JSON.stringify(storedValue));
+    } catch (error) {
+      console.warn(`useLocalStorage: Failed to write key "${key}"`, error);
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setStoredValue] as const;
+}

--- a/index.css
+++ b/index.css
@@ -1,0 +1,23 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f8fafc;
+}
+
+button {
+  cursor: pointer;
+}
+
+textarea {
+  resize: vertical;
+}
+
+* {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- implement user onboarding, dashboard, goal, activity, and review screens with Tailwind UI
- add reusable icon set and local storage hook used across screens
- include base stylesheet for consistent typography and spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9ed0ce82083249bd57d08c282f1ff