### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy 12 Week Year Planner
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build app
+        run: npm run build
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Upload production-ready app
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Run and deploy your AI Studio app
 
-This contains everything you need to run your app locally.
+This contains everything you need to run your app locally or publish it as a GitHub Pages site.
 
 View your app in AI Studio: https://ai.studio/apps/temp/1
 
@@ -12,9 +12,16 @@ View your app in AI Studio: https://ai.studio/apps/temp/1
 
 **Prerequisites:**  Node.js
 
+1. Install dependencies: `npm install`
+2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key.
+3. Run the app: `npm run dev`
 
-1. Install dependencies:
-   `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+## Continuous deployment to GitHub Pages
+
+Pushes to `main` automatically build and deploy the production site via [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml).
+
+1. In your GitHub repository, navigate to **Settings → Secrets and variables → Actions** and add a repository secret named `GEMINI_API_KEY` with your Gemini API key so the workflow can build the app.
+2. Enable GitHub Pages by setting the **Source** to **GitHub Actions** the first time the workflow runs (GitHub usually prompts you automatically).
+3. Merge or push to `main` (or run the workflow manually from the **Actions** tab). The job installs dependencies, runs `npm run build`, and publishes the generated `dist/` folder.
+
+Once the deployment completes, your live app is available at `https://<your-github-username>.github.io/<repository-name>/`. Replace the placeholders with your actual GitHub username and repository name to share a clickable link where anyone can try the planner.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: mode === 'production' ? './' : '/',
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Vite app and deploys it to GitHub Pages on pushes to main
- configure the Vite base path so static assets resolve correctly when published from a subdirectory
- extend the README with instructions for configuring the deployment and sharing the live link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9f02acf988324aa944e0875daae22